### PR TITLE
Fix tests for solidus 2.6 (only tested version)

### DIFF
--- a/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
+++ b/app/controllers/solidus_subscriptions/api/v1/line_items_controller.rb
@@ -16,7 +16,7 @@ class SolidusSubscriptions::Api::V1::LineItemsController < Spree::Api::BaseContr
     return render json: {}, status: 400 if @line_item.order.complete?
 
     @line_item.destroy!
-    @line_item.order.update!
+    @line_item.order.recalculate
 
     render json: @line_item.to_json
   end

--- a/app/models/solidus_subscriptions/checkout.rb
+++ b/app/models/solidus_subscriptions/checkout.rb
@@ -65,12 +65,11 @@ module SolidusSubscriptions
     private
 
     def checkout
-      order.update!
+      order.recalculate
       apply_promotions
 
       order.checkout_steps[0...-1].each do
         order.ship_address = ship_address if order.state == "address"
-        create_payment if order.state == "payment"
         order.next!
       end
 
@@ -114,15 +113,7 @@ module SolidusSubscriptions
     end
 
     def active_card
-      user.credit_cards.default.last
-    end
-
-    def create_payment
-      order.payments.create(
-        source: active_card,
-        amount: order.total,
-        payment_method: Config.default_gateway
-      )
+      user.wallet.default_wallet_payment_source
     end
 
     def apply_promotions

--- a/app/models/solidus_subscriptions/subscription.rb
+++ b/app/models/solidus_subscriptions/subscription.rb
@@ -7,7 +7,7 @@ module SolidusSubscriptions
 
     PROCESSING_STATES = [:pending, :failed, :success]
 
-    belongs_to :user, class_name: Spree.user_class
+    belongs_to :user, class_name: Spree::UserClassHandle.new
     has_many :line_items, class_name: 'SolidusSubscriptions::LineItem', inverse_of: :subscription
     has_many :installments, class_name: 'SolidusSubscriptions::Installment'
     belongs_to :store, class_name: 'Spree::Store'

--- a/app/models/solidus_subscriptions/subscription_line_item_builder.rb
+++ b/app/models/solidus_subscriptions/subscription_line_item_builder.rb
@@ -9,7 +9,7 @@ module SolidusSubscriptions
 
       # Rerun the promotion handler to pickup subscription promotions
       Spree::PromotionHandler::Cart.new(line_item.order).activate
-      line_item.order.update!
+      line_item.order.recalculate
     end
 
     def subscription_params

--- a/app/views/spree/admin/subscriptions/edit.html.erb
+++ b/app/views/spree/admin/subscriptions/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title) { t('.title') } %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('.back'), admin_subscriptions_path %></li>
+  <li><%= link_to t('.back'), admin_subscriptions_path, class: 'btn btn-primary' %></li>
 <% end %>
 
 <% content_for :sidebar_title do %>

--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('.new_subscription'), new_admin_subscription_path %></li>
+  <li><%= link_to t('.new_subscription'), new_admin_subscription_path, class: 'btn btn-primary' %></li>
 <% end %>
 
 <% content_for :table_filter_title do %>
@@ -83,7 +83,7 @@
     <div class="clearfix"></div>
 
     <div class="actions filter-actions">
-      <div><%= button Spree.t(:filter_results) %></div>
+      <div><%= button_to Spree.t(:filter_results), type: 'submit' %></div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/spree/admin/subscriptions/new.html.erb
+++ b/app/views/spree/admin/subscriptions/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title) { t('.title') } %>
 
 <% content_for :page_actions do %>
-  <li><%= button_link_to t('.back'), admin_subscriptions_path %></li>
+  <li><%= link_to t('.back'), admin_subscriptions_path, class: 'btn btn-primary' %></li>
 <% end %>
 
 <%= form_for @subscription, url: spree.admin_subscriptions_url, class: "row" do |f| %>

--- a/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
+++ b/lib/solidus_subscriptions/testing_support/factories/subscription_factory.rb
@@ -6,7 +6,9 @@ FactoryGirl.define do
 
     user do
       create(:user, :subscription_user).tap do |user|
-        create(:credit_card, gateway_customer_profile_id: 'BGS-123', user: user, default: true)
+        cc = create(:credit_card, gateway_customer_profile_id: 'BGS-123', user: user)
+        wallet_cc = user.wallet.add(cc)
+        user.wallet.default_wallet_payment_source = wallet_cc
       end
     end
 

--- a/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/line_items_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe SolidusSubscriptions::Api::V1::LineItemsController, type: :contro
         token: user.spree_api_key
       }
     end
-    subject { post :update, params: params }
+
+    subject { post :update, params: params, format: :json }
 
     context 'guest user' do
       let(:order) { create :order }
@@ -87,7 +88,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::LineItemsController, type: :contro
 
   describe "#destroy" do
     let(:params) { { id: line.id, order_id: order.id, token: user.spree_api_key } }
-    subject { delete :destroy, params: params }
+    subject { delete :destroy, params: params, format: :json }
 
     context "when the order is not ours" do
       let(:order) { create :order, user: create(:user) }

--- a/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
+++ b/spec/controllers/solidus_subscriptions/api/v1/subscriptions_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
   end
 
   describe 'PATCH :update' do
-    subject { patch :update, params: params }
+    subject { patch :update, params: params, format: :json }
     let(:params) do
       {
         id: subscription.id,
@@ -40,6 +40,8 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
         subscription: subscription_params
       }
     end
+
+    let!(:state) { create :state }
 
     let(:subscription_params) do
       {
@@ -52,8 +54,8 @@ RSpec.describe SolidusSubscriptions::Api::V1::SubscriptionsController, type: :co
           lastname: 'Ketchum',
           address1: '1 Rainbow Road',
           city: 'Palette Town',
-          country_id: create(:country).id,
-          state_id: create(:state).id,
+          country_id: state.country.id,
+          state_id: state.id,
           phone: '999-999-999',
           zipcode: '10001'
         }

--- a/spec/lib/solidus_subscriptions/processor_spec.rb
+++ b/spec/lib/solidus_subscriptions/processor_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe SolidusSubscriptions::Processor, :checkout do
 
   let!(:user) do
     create(:user, :subscription_user).tap do |user|
-      create(:credit_card, gateway_customer_profile_id: 'BGS-123', user: user, default: true)
+      cc = create(:credit_card, gateway_customer_profile_id: 'BGS-123', user: user)
+      wallet_cc = user.wallet.add(cc)
+      user.wallet.default_wallet_payment_source = wallet_cc
     end
   end
 


### PR DESCRIPTION
Fixes test errors and cleans up Solidus deprecation warnings

```sh
winpty docker-compose run ss bundle exec rspec
Starting solidus_subscriptions_ss_db_1 ... done
The factory_girl gem has been deprecated and has been replaced by factory_bot. Please switch to factory_bot as soon as
 possible.
NOTE: Specification.all called from /myapp/spec/models/solidus_subscriptions/checkout_spec.rb:110:in `block (2 levels)
 in <top (required)>'

Randomized with seed 52302
......................................................................................................................
......................................................................................................................
...........................DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be
 changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `sa
ve` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_change_to_attrib
ute?` instead. (called from generate_spree_api_key! at /usr/local/bundle/bundler/gems/solidus-1b27e30d8fac/core/app/mo
dels/concerns/spree/user_api_authentication.rb:7)
.DEPRECATION WARNING: The behavior of `attribute_changed?` inside of after callbacks will be changing in the next vers
ion of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opp
osite of what it returns now). To maintain the current behavior, use `saved_change_to_attribute?` instead. (called fro
m generate_spree_api_key! at /usr/local/bundle/bundler/gems/solidus-1b27e30d8fac/core/app/models/concerns/spree/user_a
pi_authentication.rb:7)
.......................

Finished in 2 minutes 37.3 seconds (files took 5.98 seconds to load)
287 examples, 0 failures

Randomized with seed 52302

Coverage report generated for RSpec to /myapp/coverage. 685 / 686 LOC (99.85%) covered.
Coverage (99.85%) is below the expected minimum coverage (100.00%).

```